### PR TITLE
Fix DB session problem in tests

### DIFF
--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -6,6 +6,7 @@ from contextlib import closing
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.engine.url import make_url
+from tests.unit_tests.helpers import login
 
 from server.database import Category, Flavor, Kind, Price, Role, Shop, Tag, User, db, user_datastore
 
@@ -129,7 +130,7 @@ def member_logged_in(member):
 
 
 @pytest.fixture
-def shop_unconfirmed(user_roles):
+def shop_admin_unconfirmed(user_roles):
     user = user_datastore.create_user(username="shop", password=SHOP_PASSWORD, email=SHOP_EMAIL)
     user_datastore.add_role_to_user(user, "shop")
     db.session.commit()
@@ -137,7 +138,7 @@ def shop_unconfirmed(user_roles):
 
 
 @pytest.fixture
-def shop(shop_unconfirmed):
+def shop_admin(shop_admin_unconfirmed):
     user = User.query.filter(User.email == SHOP_EMAIL).first()
     user.confirmed_at = datetime.datetime.utcnow()
     db.session.commit()
@@ -145,11 +146,10 @@ def shop(shop_unconfirmed):
 
 
 @pytest.fixture
-def teacher_logged_in(teacher):
-    user = User.query.filter(User.email == SHOP_EMAIL).first()
-    # Todo: actually login/handle cookie
-    # db.session.commit()
-    return user
+def shop_admin_logged_in(shop_admin, client):
+    response = login(client, SHOP_EMAIL, SHOP_PASSWORD)
+    assert response.status_code == 200
+    return client
 
 
 @pytest.fixture

--- a/tests/unit_tests/test_accounts.py
+++ b/tests/unit_tests/test_accounts.py
@@ -21,7 +21,7 @@ def test_unconfirmed_member_login(client, member_unconfirmed):
     assert response.status_code == 400
 
 
-def test_shop_login(client, shop):
+def test_shop_login(client, shop_admin):
     """Make sure login and logout works."""
     response = login(client, SHOP_EMAIL, SHOP_PASSWORD)
     assert response.status_code == 200
@@ -33,7 +33,7 @@ def test_shop_login(client, shop):
     assert response.json["response"]["errors"]["password"] == ["Invalid password"]
 
 
-def test_unconfirmed_shop_login(client, shop_unconfirmed):
+def test_unconfirmed_shop_login(client, shop_admin_unconfirmed):
     """Make sure login shows confirmation error."""
     response = login(client, SHOP_EMAIL, SHOP_PASSWORD)
     assert response.json["response"]["errors"]["email"][0] == "Email requires confirmation."

--- a/tests/unit_tests/test_kind_to_tags_endpoint.py
+++ b/tests/unit_tests/test_kind_to_tags_endpoint.py
@@ -5,32 +5,48 @@ from database import Kind, Tag, db
 
 
 def test_add_tag_to_kind(client):
-    # somehow check_quick_token() loses the request in test setup
-    with mock.patch("flask_security.decorators._check_token", return_value=True):
-        with mock.patch("flask_principal.Permission.can", return_value=True):
-            kind_id = str(uuid.uuid4())
-            kind = Kind(
-                id=kind_id,
-                name="Indica",
-                c=False,
-                h=False,
-                i=True,
-                s=False,
-                short_description_nl="Short NL",
-                description_nl="Description NL",
-                short_description_en="Short NL",
-                description_en="Description EN",
-            )
-            tag = Tag(id=str(uuid.uuid4()), name="Gigly")
-            db.session.add(kind)
-            db.session.add(tag)
-            db.session.commit()
+    # @Guido: This tests shouldn't need:
+    # - the manual setup of a Kind and a Tag
+    #   (I've fixtures for them but they don't seem to work ok
+    # - the mock patch for simulated user login.
+    #   (I've a fixture for a user shop_admin that works fine for account tests, like `test_shop_login()`)
 
-            data = {"kind_id": str(kind.id), "tag_id": str(tag.id), "amount": 60}
-            response = client.post(f"/v1/kinds-to-tags", json=data, follow_redirects=True)
-            assert response.status_code == 201
+    with mock.patch("flask_principal.Permission.can", return_value=True):
+        kind_id = str(uuid.uuid4())
+        kind = Kind(
+            id=kind_id,
+            name="Indica",
+            c=False,
+            h=False,
+            i=True,
+            s=False,
+            short_description_nl="Short NL",
+            description_nl="Description NL",
+            short_description_en="Short NL",
+            description_en="Description EN",
+        )
+        tag = Tag(id=str(uuid.uuid4()), name="Gigly")
+        db.session.add(kind)
+        db.session.add(tag)
+        db.session.commit()
 
-            response = client.get(f"/v1/kinds-to-tags", follow_redirects=True)
-            assert response.status_code == 200
-            json = response.json
-            assert len(json) == 1
+        data = {"kind_id": str(kind.id), "tag_id": str(tag.id), "amount": 60}
+        response = client.post(f"/v1/kinds-to-tags", json=data, follow_redirects=True)
+        assert response.status_code == 201
+
+        response = client.get(f"/v1/kinds-to-tags", follow_redirects=True)
+        assert response.status_code == 200
+        json = response.json
+        assert len(json) == 1
+
+
+def test_add_tag_to_kind_with_fixtures(shop_admin_logged_in, kind_1, tag_1):
+    data = {"kind_id": str(kind_1.id), "tag_id": str(tag_1.id), "amount": 60}
+
+    response = shop_admin_logged_in.post(f"/v1/kinds-to-tags", json=data, follow_redirects=True)
+    assert response.status_code == 201
+
+    response = shop_admin_logged_in.get(f"/v1/kinds-to-tags", follow_redirects=True)
+    assert response.status_code == 200
+    json = response.json
+    assert len(json) == 1


### PR DESCRIPTION
Implementing delete.

Specs:
- Prices won't have delete for now (we work with a fixed 80 items product code)
- To make editing of Flavors and Effects easier a cascaded delete will be performed when you try to remove a Tag or Flavor (it will remove itself from all Product Kinds)
- Deleting a ProductKind will also delete active prices relations ships for it
- Deleting a Shop or a Category: will also delete active prices relations ships for it
- Rest of the endpoint will not cascade to be safer: just delete a record and fail when it has relation ships